### PR TITLE
Add support for scrollkey extractor as a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,12 +76,8 @@ export default class AlphaScrollFlatList extends Component {
 
                 index = this.props.reverse ? lastIndex : firstIndex;
             } else {
-                if(typeof this.props.scrollKey === 'function') {
-                    index = this.props.data.findIndex(item => this.props.scrollKey(item).charAt(0).localeCompare(letter) === 0);
-                } else {
-                    //Get index of item with that letter and scroll to the first result on the list
-                    index = this.props.data.findIndex(item => item[this.props.scrollKey].charAt(0).localeCompare(letter) === 0);
-                }
+                const scrollKeyIsFunction = typeof this.props.scrollKey === 'function';
+                index = this.props.data.findIndex(item =>(scrollKeyIsFunction ? this.props.scrollKey(item) : item[this.props.scrollKey]).charAt(0).localeCompare(letter) === 0);
             }
 
             if (index !== -1)

--- a/src/index.js
+++ b/src/index.js
@@ -76,8 +76,12 @@ export default class AlphaScrollFlatList extends Component {
 
                 index = this.props.reverse ? lastIndex : firstIndex;
             } else {
-                //Get index of item with that letter and scroll to the first result on the list
-                index = this.props.data.findIndex(item => item[this.props.scrollKey].charAt(0).localeCompare(letter) === 0);
+                if(typeof this.props.scrollKey === 'function') {
+                    index = this.props.data.findIndex(item => this.props.scrollKey(item).charAt(0).localeCompare(letter) === 0);
+                } else {
+                    //Get index of item with that letter and scroll to the first result on the list
+                    index = this.props.data.findIndex(item => item[this.props.scrollKey].charAt(0).localeCompare(letter) === 0);
+                }
             }
 
             if (index !== -1)
@@ -152,7 +156,10 @@ export default class AlphaScrollFlatList extends Component {
 
 AlphaScrollFlatList.propTypes = {
     hideSideBar: PropTypes.bool,
-    scrollKey: PropTypes.string,
+    scrollKey: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func
+    ]),
     reverse: PropTypes.bool,
     itemHeight: PropTypes.number,
     data: PropTypes.array,


### PR DESCRIPTION
Provides support for defining `scrollKey` as a function instead of a string, similar to `keyExtractor` in a FlatList.